### PR TITLE
Adding mail to the request for logging

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -141,7 +141,7 @@ def transcribe():
 
             job = rq_queue.enqueue(
                 'transcriber.transcribe',
-                args=(filename, requestedModel, task, language),
+                args=(filename, requestedModel, task, language,email),
                 result_ttl=3600*24*7,
                 job_timeout=3600*4,
                 meta={

--- a/src/main.py
+++ b/src/main.py
@@ -143,7 +143,7 @@ def transcribe():
 
             job = rq_queue.enqueue(
                 'transcriber.transcribe',
-                args=(filename, requestedModel, task, language,email),
+                args=(filename, requestedModel, task, language, email),
                 result_ttl=3600*24*7,
                 job_timeout=3600*4,
                 meta={

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -1,6 +1,8 @@
 import whisper
 
 def transcribe(filename, requestedModel, task, language,email):
+    # Mail is not used here, but it makes it easier for the worker to log mail
+    print("Executing transcribing of " + filename + " for "+ email + " using " + model + " model ")
     model = whisper.load_model(requestedModel)
 
     return model.transcribe(filename, language=language, task=task)

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -1,6 +1,6 @@
 import whisper
 
-def transcribe(filename, requestedModel, task, language):
+def transcribe(filename, requestedModel, task, language,email):
     model = whisper.load_model(requestedModel)
 
     return model.transcribe(filename, language=language, task=task)


### PR DESCRIPTION
Sending the mail as a parameter is the easiest way to see user run in the worker. Fetching from metadata was hard :-(