### PR TITLE
chore: use new openai-whisper package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.1.3
-whisper @ git+https://github.com/openai/whisper.git@28769fcfe50755a817ab922a7bc83483159600a9
+openai-whisper==20230117
 pytest==7.2.1
 redis==4.4.2
 rq==1.12.0


### PR DESCRIPTION
Use the new openai-whisper release to allow dependabot to auto update whisper

https://github.com/openai/whisper/commit/37a4f1be6d178bc8dad010dc33bcbbc69350e6bf