### PR TITLE
Move sanitize input to utils and create test

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,8 @@ from rq.exceptions import NoSuchJobError
 from src import callbacks
 from src.utils import (
     generate_srt, generate_vtt, generate_text,
-    get_total_time_transcribed, generate_jojo_doc
+    get_total_time_transcribed, generate_jojo_doc,
+    sanitize_input
 )
 
 SENTRY_DSN = os.environ.get("SENTRY_DSN")
@@ -231,8 +232,7 @@ def download(job_id):
             return "No such job", 404
         set_user({"email": job.meta.get('email')})
         if job.is_finished:
-            filename = job.meta.get("uploaded_filename").encode(
-                "latin-1", errors="ignore")
+            filename = sanitize_input(job.meta.get("uploaded_filename"))
 
             if output == "txt":
                 return Response(

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,6 +2,9 @@ from uuid import uuid4
 from math import floor
 from json import dumps
 
+def sanitize_input(text):
+    return str(text.encode("latin-1", errors="ignore").decode("latin-1"))
+
 def get_total_time_transcribed(conn):
     total_time_transcribed = conn.get("waas:total_time_transcribed")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ def test_get_time_as_hundreds():
     assert hundred == 1110
 
 def test_generate_jojo_doc():
-    filename = "test"
+    filename = "test_with_norwegian_chars_ÆøÅæØå"
     result = [
         {
             "avg_logprob": -0.23971951974404826,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from src.utils import generate_jojo_doc, get_time_as_hundreds
+from src.utils import generate_jojo_doc, get_time_as_hundreds, sanitize_input
 import json
 
 def test_get_time_as_hundreds():
@@ -129,8 +129,20 @@ def test_generate_jojo_doc():
         }
     ]
     output = json.loads(generate_jojo_doc(filename, result))
-    assert 'audiofile' in output
-    assert 'segments' in output
-    assert 'id' in output
-    assert 'docVersion' in output
-    assert len(output['segments']) == 4, "Should be 4 segments in output"
+    assert "audiofile" in output
+    assert "segments" in output
+    assert "id" in output
+    assert "docVersion" in output
+    assert len(output["segments"]) == 4, "Should be 4 segments in output"
+
+
+def test_sanitize_input():
+    filenames = {
+        "øæå": "øæå",
+        "ÆÅØ": "ÆÅØ",
+        "öäë": "öäë",
+        "@!": "@!",
+    }
+
+    for fn in filenames:
+        assert fn == sanitize_input(filenames[fn])


### PR DESCRIPTION
The encode to latin-1 returned a byte object. It was important to decode it back to a string to use it in headers, part of JSON structure and more. 