### PR TITLE
Fix/filename for mac

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ gunicorn==20.1.0
 sentry-sdk==1.13.0
 blinker==1.5
 Werkzeug==2.0.3
+Unidecode==1.3.6

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,7 +6,7 @@ from unidecode import unidecode
 from urllib.parse import quote_plus
 
 def sanitize_input(text):
-    return sub("[^A-Za-z0-9A+]", "_", unidecode(str(text.encode("latin-1", errors="ignore").decode("latin-1"))))
+    return sub("[^A-Za-z0-9+]", "_", unidecode(str(text.encode("latin-1", errors="ignore").decode("latin-1"))))
 
 def get_total_time_transcribed(conn):
     total_time_transcribed = conn.get("waas:total_time_transcribed")

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,6 +3,7 @@ from math import floor
 from json import dumps
 from re import sub
 from unidecode import unidecode
+from urllib.parse import quote_plus
 
 def sanitize_input(text):
     return sub("[^A-Za-z0-9A+]", "_", unidecode(str(text.encode("latin-1", errors="ignore").decode("latin-1"))))
@@ -83,7 +84,7 @@ def generate_jojo_doc(filename, result):
         "id": get_uuid(),
         "audiofile": {
             "id": get_uuid(),
-            "url": "file://web/" + filename
+            "url": "file://web/" + quote_plus(filename)
         },
         "segments": []
     }

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,9 +2,10 @@ from uuid import uuid4
 from math import floor
 from json import dumps
 from re import sub
+from unidecode import unidecode
 
 def sanitize_input(text):
-    return sub("[^\w+]", "_", str(text.encode("latin-1", errors="ignore").decode("latin-1")))
+    return sub("[^A-Za-z0-9A+]", "_", unidecode(str(text.encode("latin-1", errors="ignore").decode("latin-1"))))
 
 def get_total_time_transcribed(conn):
     total_time_transcribed = conn.get("waas:total_time_transcribed")
@@ -82,7 +83,7 @@ def generate_jojo_doc(filename, result):
         "id": get_uuid(),
         "audiofile": {
             "id": get_uuid(),
-            "url": "file://" + filename
+            "url": "file://web/" + filename
         },
         "segments": []
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,6 +142,7 @@ def test_sanitize_input():
         "ÆÅØ": "AEAO",
         "öäë": "oae",
         "@!": "__",
+        "test med blåbærsyltetøy og 🎉 og fest 🇳🇴": "test_med_blabaersyltetoy_og__og_fest_",
         "filename with space": "filename_with_space",
         "filename%20with%20encode": "filename_20with_20encode",
         "filename with date in (2023-01-20)": "filename_with_date_in__2023_01_20_",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -138,9 +138,9 @@ def test_generate_jojo_doc():
 
 def test_sanitize_input():
     filenames = {
-        "øæå": "øæå",
-        "ÆÅØ": "ÆÅØ",
-        "öäë": "öäë",
+        "øæå": "oaea",
+        "ÆÅØ": "AEAO",
+        "öäë": "oae",
         "@!": "__",
         "filename with space": "filename_with_space",
         "filename%20with%20encode": "filename_20with_20encode",


### PR DESCRIPTION
Mac app var not happy with unencoded version of the chars so I removed them. It make sense to use the same logic everywhere, since we use the filename in the headers. To really make sure I also encode the filename in the Jojo-doc.