### PR TITLE
add nvidia Docker setup

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,0 +1,22 @@
+FROM nvidia/cuda:12.0.1-base-ubuntu22.04
+
+ENV PYTHON_VERSION=3.10
+
+WORKDIR /workspace
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -qq update \
+    && apt-get -qq install --no-install-recommends \
+    git \
+    ffmpeg \
+    python${PYTHON_VERSION} \
+    python${PYTHON_VERSION}-venv \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
+
+COPY src src
+
+CMD [ "flask", "--app" , "src/main", "--debug", "run","--host", "0.0.0.0","--port", "3000"]

--- a/README.md
+++ b/README.md
@@ -141,6 +141,39 @@ This will start three docker containers.
 - api running flask fra src
 - worker running rq from src
 
+### Using NVIDIA CUDA with docker-compose
+
+If you have a NVIDIA GPU and want to use it with docker-compose,
+you need to install [nvidia-docker](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker).
+
+To enable CUDA support, you need to edit the `docker-compose.yml` file to use the `nvidia` runtime:
+
+```yaml
+build:
+    context: .
+    # use Dockerfile.gpu when using a NVIDIA GPU
+    dockerfile: Dockerfile.gpu
+```
+
+You also have to uncomment the device reservation in the `docker-compose.yml` file:
+
+```yaml
+deploy:
+    resources:
+        reservations:
+            devices:
+                - driver: nvidia
+                  capabilities: [gpu]
+```
+
+Then run the following command as usual:
+
+```sh
+docker-compose --env-file .envrc up
+```
+
+The worker will now use the GPU acceleration.
+
 ### Running full setup using devcontainers
 
 Install remote-development extensions (containers)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,10 @@
 version: "3.9"
 services:
     api:
-        build: .
+        build:
+            context: .
+            # use Dockerfile.gpu when using a NVIDIA GPU
+            dockerfile: Dockerfile
         ports:
             - "3000:3000"
         volumes:
@@ -16,7 +19,10 @@ services:
             - DISCLAIMER
         command: gunicorn -w 2 -b 0.0.0.0:3000 --log-file=- 'src.main:app'
     worker:
-        build: .
+        build:
+            context: .
+            # use Dockerfile.gpu when using a NVIDIA GPU
+            dockerfile: Dockerfile
         volumes:
             - .:/workspace
         depends_on:
@@ -27,6 +33,13 @@ services:
             - EMAIL_SENDER_PASSWORD
             - EMAIL_SENDER_HOST
         command: rq worker --url redis://redis:6379 -c worker-settings
+        # Uncomment the following lines when using a NVIDIA GPU
+        # deploy:
+        #     resources:
+        #         reservations:
+        #             devices:
+        #                 - driver: nvidia
+        #                   capabilities: [gpu]
 
     redis:
         image: redis


### PR DESCRIPTION
# Description

Whisper heavily benefits from NVIDIA CUDA.
In my opinion, this project should support a setup in which GPU's are being used.

I added the following:
* `Dockerfile.gpu`: a separate Dockerfile for people who want to use CUDA.
* `README.md`: added the section `Using NVIDIA CUDA with docker-compose`
* `docker-compose.yml`: prepared the file for people who want to use CUDA

This effectively results in GPU support for the project.

This is just a suggestion on how I would implement CUDA support for the project!
Feel free to request changes to my PR! I'm also able to test everything in regard to CUDA.

Suggestion:
The CUDA image is based on Ubuntu.
In case you like my suggested changes, it could make sense to move `Dockerfile` to something closer to Ubuntu -> both Dockerfiles would be more similar.

# Checklist:

- [ ] My code has been linted to follow the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
