### PR TITLE
Download blob instead of base64

### DIFF
--- a/src/static/src/components/Editor.js
+++ b/src/static/src/components/Editor.js
@@ -68,6 +68,11 @@ const Editor = ({ jojoDoc }) => {
     const data = async () => {
       switch (type) {
         case "jojo":
+          if (audio) {
+            jojoDoc.audiofile.url = "file:///web/" + audio.name;
+          } else {
+            jojoDoc.audiofile = { id: "472F9DBB-C9CC-4A10-9DE7-979F521EEECE" };
+          }
           return JSON.stringify(jojoDoc);
           break;
 
@@ -111,9 +116,8 @@ const Editor = ({ jojoDoc }) => {
           break;
       }
     };
-    a.href =
-      "data:application/octet-stream;charset=utf-8;base64," +
-      btoa(await data());
+    const blob = new Blob([await data()], { type: "octet/stream" });
+    a.href = window.URL.createObjectURL(blob);
     a.click();
   };
 
@@ -149,7 +153,12 @@ const Editor = ({ jojoDoc }) => {
       </div>
     </main>
     <div class="table-container">
-      <${Table} hasAudio=${audio} jojoDoc=${jojoDoc} setCursor=${setCursor} audio=${audio} />
+      <${Table}
+        hasAudio=${audio}
+        jojoDoc=${jojoDoc}
+        setCursor=${setCursor}
+        audio=${audio}
+      />
     </div>
   </div>`;
 };


### PR DESCRIPTION
This will make sure we download the file with utf-8 file encoding instead of ISO-8859-1

# Checklist:

- [x] My code has been linted to follow the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
