### PR TITLE
Fix service property name in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 
 	// The 'service' property is the name of the service for the container that VS Code should
 	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
-	"service": "waas-api",
+	"service": "api",
 
 	// The optional 'workspaceFolder' property is the path VS Code should open by default when
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml


### PR DESCRIPTION
# Description

Service is named 'api' in docker-compose.yml and not 'waas-api'
devcontainer.json updated.

# Checklist:

- [x] ~~My code has been linted to follow the code style of this project~~
- [x] ~~I have performed a self-review of my own code~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
